### PR TITLE
WIP: Add dotenv

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,4 @@
+# ethereum-goerli-rpc.allthatnode.com
+# rpc.ankr.com/base_goerli/123
+URL_ANKR_JSON_RPC_GOERLI=ethereum-goerli-rpc.allthatnode.com
+PRIVATE_KEY_GOERLI=

--- a/README.md
+++ b/README.md
@@ -18,18 +18,29 @@ gh repo create zkgraph-new --public --template="https://github.com/hyperoracle/z
 
 ### Configuration
 
-After clone your project, you need to create `config.js` file at root folder based on `config-example.js`
+After cloning your project, you need to create `config.js` file at root folder based on `config-example.js`
+
+Generate an environment file by running `cp .env-example .env`.
+
+If you wish to use ANKR to create JSON RPC requests to the Ethereum Goerli Testnet then go to https://www.ankr.com/rpc/ and click "Base Goerli Testnet" and then copy the "HTTPS Endpoint" value and paste it as the value of `URL_ANKR_JSON_RPC_GOERLI` in the .env file.
+
+Lastly paste the private key of an Ethereum address that has Goerli Testnet Eth as the value of `PRIVATE_KEY_GOERLI` in the .env file. To obtain Goerli Testnet Eth refer to [this article](https://www.coingecko.com/learn/goerli-eth).
 
 ```js
 // ./config.js
 export const config = {
-  // Update your Etherum JSON RPC provider URL here.
+  // Update your Ethereum JSON RPC provider URL here.
   // Please note that the provider must support debug_getRawReceipts RPC method.
   // Recommended provider: ANKR.
-  JsonRpcProviderUrl: "https://{URL}",
-  UserPrivateKey: "0x{PRIVATE_KEY}",
+  JsonRpcProviderUrl: "https://{URL_ANKR_JSON_RPC_GOERLI}",
+  UserPrivateKey: "0x{PRIVATE_KEY_GOERLI}",
   // ...and other configs.
 };
+```
+
+> To check if the provider supports the [`debug_getRawReceipts`](https://github.com/ethereum/go-ethereum/pull/24773) JSON RPC method, check if the following returns a response `{"jsonrpc":"2.0","id":42,"result":["...}`. In the example below the argument is the block hash (i.e. 0x3bb580f7645e2bdeb34b226f1b559d22a4a1ba5e2474504e294088389923ebd0) of a block number (i.e. 9438739) on the Goerli Testnet where the provider JSON RPC endpoint was obtained from https://ethereum-goerli-rpc.allthatnode.com
+```bash
+curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"debug_getRawReceipts","params":["0x3bb580f7645e2bdeb34b226f1b559d22a4a1ba5e2474504e294088389923ebd0"],"id":42}' https://ethereum-goerli-rpc.allthatnode.com
 ```
 
 Then run:
@@ -63,6 +74,8 @@ npm run compile-local
 ```bash
 npm run exec-local -- {block_id}
 ```
+
+Note: If using Ethereum Goerli Testnet then replace the `block_id` above with a block from https://goerli.etherscan.io/blocks
 
 ### Set Up Local Image
 

--- a/api/common/bundle.js
+++ b/api/common/bundle.js
@@ -14,6 +14,18 @@ async function instantiate(module, imports = {}) {
         text = __liftString(text >>> 0);
         console.log(text);
       },
+      // FIXME - if you use provider connected to Goerli Testnet and run
+      // `npm run exec-local -- 9438792` then it returns the following error
+      // since `x` below is not defined
+      //
+      // ```
+      // [-] zkwasm require condition is false
+      // file:///Users/luke/code/github/ltfschoen/zkgraph/api/common/zkwasm_mock.js:79
+      //       throw Error("Abort execution");
+      //             ^
+      // Error: Abort execution
+      // ```
+
       require(x) {
         // sdk/zkwasm/require1(i32) => i64
         ZKWASMMock.require(x);

--- a/api/compile.js
+++ b/api/compile.js
@@ -84,7 +84,7 @@ if (currentNpmScriptName() === "compile-local") {
   // Compile Locally
   localCompile(config.LocalWasmBinPath, watPath);
 } else if (currentNpmScriptName() === "compile") {
-  // Test Compile Erro with Local Compile
+  // Test Compile Error with Local Compile
   localCompile("build/tmp.wasm", "build/tmp.wat");
 
   // Only Call Compile Server When No Local Compile Errors

--- a/api/exec.js
+++ b/api/exec.js
@@ -67,6 +67,7 @@ let wasmPath;
 
 let asmain_exported;
 if (currentNpmScriptName() === "exec-local") {
+  // e.g. build/zkgraph_local.wasm
   wasmPath = config.LocalWasmBinPath;
   const { asmain } = await instantiateWasm(wasmPath);
   asmain_exported = asmain;
@@ -76,7 +77,6 @@ if (currentNpmScriptName() === "exec-local") {
   asmain_exported = asmain;
   __as_start();
 }
-
 // Execute zkgraph that would call mapping.ts
 let state = asmain_exported(rawReceipts, matchedEventOffsets);
 

--- a/config-example.js
+++ b/config-example.js
@@ -1,10 +1,12 @@
+import 'dotenv/config'
+
 export const config = {
-  // Update your Etherum JSON RPC provider URL here.
+  // Update your Ethereum JSON RPC provider URL here.
   // Please note that the provider must support debug_getRawReceipts RPC method.
-  JsonRpcProviderUrl: "https://{URL}",
-  // Update your private key here to sign zkwasm messages.
-  // Please note that (during testnet phrase) your address balance (in zkwasm server) should > 0;
-  UserPrivateKey: "0x{PRIVATE_KEY}",
+  JsonRpcProviderUrl: `https://${process.env.URL_ANKR_JSON_RPC_GOERLI}`,
+  // Update your private key here to sign zkWasm messages.
+  // Please note that (during testnet phrase) your address balance (in zkWasm server) should > 0;
+  UserPrivateKey: `0x${process.env.PRIVATE_KEY_GOERLI}`,
 
   ZkwasmProviderUrl: "https://zkwasm-explorer.delphinuslab.com:8090",
   CompilerServerEndpoint: "https://compiler.hyperoracle.io/compile",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "axios": "^1.4.0",
         "commander": "^11.0.0",
+        "dotenv": "^16.3.1",
         "ethers": "^5.7.2",
         "form-data": "^4.0.0",
         "js-yaml": "^4.1.0",
@@ -795,6 +796,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/elliptic": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "axios": "^1.4.0",
     "commander": "^11.0.0",
+    "dotenv": "^16.3.1",
     "ethers": "^5.7.2",
     "form-data": "^4.0.0",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
* Add dotenv for private key and use of private endpoint
* Update README to show user how to check if `debug_getRawReceipts` is supported by a provider using cURL
* Update README with example of how to use Goerli Testnet
* Error if you run command `npm run exec-local -- 9438792`, where `9438792` is a valid block number, it crashes with error
```bash
[-] zkwasm require condition is false
file:///Users/luke/code/github/ltfschoen/zkgraph/api/common/zkwasm_mock.js:79
      throw Error("Abort execution");
            ^

Error: Abort execution
```
which happens on this line https://github.com/hyperoracle/zkgraph/blob/master/api/exec.js#L81


